### PR TITLE
Allow Flash fallback to be excluded through build configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # Ember Webcam
 [![Build Status](https://travis-ci.org/leizhao4/ember-webcam.svg?branch=master)](https://travis-ci.org/leizhao4/ember-webcam)
+[![Ember Observer Score](https://emberobserver.com/badges/ember-webcam.svg)](https://emberobserver.com/addons/ember-webcam)
 [![Code Climate](https://codeclimate.com/github/leizhao4/ember-webcam/badges/gpa.svg)](https://codeclimate.com/github/leizhao4/ember-webcam)
 [![Test Coverage](https://codeclimate.com/github/leizhao4/ember-webcam/badges/coverage.svg)](https://codeclimate.com/github/leizhao4/ember-webcam/coverage)
-[![Ember Observer Score](https://emberobserver.com/badges/ember-webcam.svg)](https://emberobserver.com/addons/ember-webcam)
 
-This Ember CLI addon is a simple wrapper for [WebcamJS](https://pixlcore.com/read/WebcamJS).
+This Ember CLI addon is a simple wrapper for
+[WebcamJS](https://pixlcore.com/read/WebcamJS) 1.x.
 
 ## Installation
 
@@ -14,11 +15,17 @@ ember install ember-webcam
 
 ## Usage
 
-This addon provides an `ember-webcam` component which renders a live camera viewer. It also yields a camera controller (`camera`) to the block. This controller can be used to trigger certain camera actions, such as taking a still snapshot (`camera.snap`).
+This Ember addon provides an `ember-webcam` component which renders a live
+camera viewer. It also yields a camera controller (`camera`) to the block. This
+controller can be used to trigger certain camera actions, such as taking a still
+snapshot (`camera.snap`).
 
 The component also takes two optional closure actions:
 
-- `didSnap` will be fired after a snapshot is taken, with the data URI of the snapshot. This URI can be passed around like any URL, or be submitted to your server.
+- `didSnap` will be fired after a snapshot is taken, with the data URI of the
+snapshot. This URI can be passed around like any URL, or be submitted to your
+server.
+
 - `didError` will be fired when an error occurs.
 
 ```js
@@ -51,6 +58,37 @@ export default Component.extend({
 
 <img src={{dataUri}}>
 ```
+
+## Configurations
+
+By default, this addon will import a `webcam.swf` file from WebcamJS and include
+it in your build. This file is used as a fallback if your browser does not
+support
+[HTML5 `getUserMedia`](http://dev.w3.org/2011/webrtc/editor/getusermedia.html).
+IE and Safari are two major browsers that do not yet have the support. For more
+details, see
+[WebcamJS Docs](https://github.com/jhuckaby/webcamjs/blob/master/DOCS.md#browser-support)
+and [caniuse.com](http://caniuse.com/#search=getusermedia).
+
+This Flash fallback can be turned off by specifying `enableFlashFallback: false`
+inside the `ember-webcam` config property in your `ember-cli-build.js` file (or
+your `index.js` if you are working on an addon):
+
+```js
+module.exports = function(defaults) {
+  const app = new EmberApp(defaults, {
+    'ember-webcam': {
+      enableFlashFallback: false
+    }
+  });
+
+  // ...
+};
+```
+
+You may otherwise specify where you want `webcam.swf` to be located in your
+build, using the `flashFallbackDir` option. The default value is `'assets'`,
+meaning the file will be located at `<APP_ROOT>/assets/webcam.swf`.
 
 ## License
 

--- a/addon/components/ember-webcam.js
+++ b/addon/components/ember-webcam.js
@@ -1,13 +1,17 @@
+import config from 'ember-get-config';
 import Component from 'ember-component';
 import computed from 'ember-computed';
 import Webcam from 'webcamjs';
 import layout from '../templates/components/ember-webcam';
 
+const _enableFlashFallback = config['ember-webcam'].enableFlashFallback;
+const _flashFallbackDir = config['ember-webcam'].flashFallbackDir;
+
 export default Component.extend({
   layout,
   classNames: ['ember-webcam'],
   cameraId: computed(() => 'cam-' + Math.random().toString(36).substr(2, 10)),
-  swfLocation: '/assets/webcam.swf',
+  swfLocation: `/${_flashFallbackDir}/webcam.swf`,
   init() {
     this._super(...arguments);
     this.set('camera', {
@@ -16,7 +20,8 @@ export default Component.extend({
   },
   didRender() {
     this._super(...arguments);
-    Webcam.setSWFLocation(this.get('swfLocation'));
+    Webcam.set('enable_flash', _enableFlashFallback);
+    Webcam.set('swfURL', this.get('swfLocation'));
     Webcam.on('error', error => {
       if (!this.isDestroying && !this.isDestroyed) {
         this.get('didError')(error);

--- a/index.js
+++ b/index.js
@@ -1,26 +1,63 @@
 /* jshint node: true */
 'use strict';
 
+const defaultOptions = {
+  enableFlashFallback: true,
+  flashFallbackDir: 'assets'
+};
+
+// For ember-cli < 2.7 findHost doesnt exist so we backport from that version
+// for earlier version of ember-cli.
+// https://github.com/ember-cli/ember-cli/blame/16e4492c9ebf3348eb0f31df17215810674dbdf6/lib/models/addon.js#L533
+const findHostShim = function () {
+  let current = this;
+  let app;
+  do {
+    app = current.app || app;
+  } while (current.parent.parent && (current = current.parent));
+  return app;
+};
+
 module.exports = {
   name: 'ember-webcam',
+
   options: {
     nodeAssets: {
-      webcamjs: {
-        vendor: ['webcam.js'],
-        public: {
-          distDir: 'assets',
-          include: ['webcam.swf']
+      webcamjs() {
+        const config = {
+          vendor: ['webcam.js']
+        };
+
+        if (this.addonOptions.enableFlashFallback) {
+          config.public = {
+            destDir: this.addonOptions.flashFallbackDir,
+            include: ['webcam.swf']
+          };
         }
+
+        return config;
       }
     }
   },
-  included(parent) {
+
+  included() {
+    const findHost = this._findHost || findHostShim;
+    const app = findHost.call(this);
+
+    const userOptions = app.options && app.options[this.name] || {};
+    this.addonOptions = Object.assign({}, defaultOptions, userOptions);
+
     this._super.included.apply(this, arguments);
-    this.import('vendor/webcamjs/webcam.js', {
+
+    app.import('vendor/webcamjs/webcam.js', {
       using: [{
         transformation: 'amd',
         as: 'webcamjs'
       }]
     });
+  },
+
+  config() {
+    return { 'ember-webcam': this.addonOptions };
   }
 };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ember-webcam",
   "version": "0.0.3",
-  "description": "Ember addon for WebcamJS integration",
+  "description": "An Ember wrapper for WebcamJS 1.x.",
   "keywords": [
     "ember-addon",
     "webcam",
@@ -26,6 +26,7 @@
     "ember-cli-babel": "^5.1.7",
     "ember-cli-htmlbars": "^1.1.1",
     "ember-cli-node-assets": "^0.2.2",
+    "ember-get-config": "^0.2.1",
     "webcamjs": "^1.0.16"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -165,10 +165,6 @@ ast-types@0.8.12:
   version "0.8.12"
   resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.8.12.tgz#a0d90e4351bb887716c83fd637ebf818af4adfcc"
 
-ast-types@0.8.15:
-  version "0.8.15"
-  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.8.15.tgz#8eef0827f04dff0ec8857ba925abe3fea6194e52"
-
 ast-types@0.9.6:
   version "0.9.6"
   resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.9.6.tgz#102c9e9e9005d3e7e3829bf0c4fa24ee862ee9b9"
@@ -566,6 +562,17 @@ broccoli-config-replace@^1.1.2:
     debug "^2.2.0"
     fs-extra "^0.24.0"
 
+broccoli-file-creator@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/broccoli-file-creator/-/broccoli-file-creator-1.1.1.tgz#1b35b67d215abdfadd8d49eeb69493c39e6c3450"
+  dependencies:
+    broccoli-kitchen-sink-helpers "~0.2.0"
+    broccoli-plugin "^1.1.0"
+    broccoli-writer "~0.1.1"
+    mkdirp "^0.5.1"
+    rsvp "~3.0.6"
+    symlink-or-copy "^1.0.1"
+
 broccoli-filter@^1.2.2, broccoli-filter@^1.2.3:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/broccoli-filter/-/broccoli-filter-1.2.4.tgz#409afb94b9a3a6da9fac8134e91e205f40cc7330"
@@ -614,7 +621,7 @@ broccoli-jshint@^2.1.0:
     json-stable-stringify "^1.0.0"
     mkdirp "~0.4.0"
 
-broccoli-kitchen-sink-helpers@^0.2.5:
+broccoli-kitchen-sink-helpers@^0.2.5, broccoli-kitchen-sink-helpers@~0.2.0:
   version "0.2.9"
   resolved "https://registry.yarnpkg.com/broccoli-kitchen-sink-helpers/-/broccoli-kitchen-sink-helpers-0.2.9.tgz#a5e0986ed8d76fb5984b68c3f0450d3a96e36ecc"
   dependencies:
@@ -675,7 +682,7 @@ broccoli-plugin@1.1.0:
     rimraf "^2.3.4"
     symlink-or-copy "^1.0.1"
 
-broccoli-plugin@^1.0.0, broccoli-plugin@^1.2.0, broccoli-plugin@^1.2.1, broccoli-plugin@^1.3.0:
+broccoli-plugin@^1.0.0, broccoli-plugin@^1.1.0, broccoli-plugin@^1.2.0, broccoli-plugin@^1.2.1, broccoli-plugin@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/broccoli-plugin/-/broccoli-plugin-1.3.0.tgz#bee704a8e42da08cb58e513aaa436efb7f0ef1ee"
   dependencies:
@@ -753,6 +760,13 @@ broccoli-uglify-sourcemap@^1.0.0:
 broccoli-unwatched-tree@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/broccoli-unwatched-tree/-/broccoli-unwatched-tree-0.1.1.tgz#4312fde04bdafe67a05a967d72cc50b184a9f514"
+
+broccoli-writer@~0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/broccoli-writer/-/broccoli-writer-0.1.1.tgz#d4d71aa8f2afbc67a3866b91a2da79084b96ab2d"
+  dependencies:
+    quick-temp "^0.1.0"
+    rsvp "^3.0.6"
 
 browser-resolve@^1.11.0:
   version "1.11.2"
@@ -1672,6 +1686,13 @@ ember-export-application-global@^1.0.5:
   resolved "https://registry.yarnpkg.com/ember-export-application-global/-/ember-export-application-global-1.1.1.tgz#f257d5271268932a89d7392679ce4db89d7154af"
   dependencies:
     ember-cli-babel "^5.1.10"
+
+ember-get-config@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/ember-get-config/-/ember-get-config-0.2.1.tgz#a1325cceefcb4534c78fc6ccb2be87a3feda6817"
+  dependencies:
+    broccoli-file-creator "^1.1.1"
+    ember-cli-babel "^5.1.6"
 
 ember-load-initializers@^0.6.0:
   version "0.6.3"
@@ -3682,7 +3703,7 @@ qs@~6.2.0:
   version "6.2.3"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.2.3.tgz#1cfcb25c10a9b2b483053ff39f5dfc9233908cfe"
 
-quick-temp@0.1.6, quick-temp@^0.1.2, quick-temp@^0.1.3, quick-temp@^0.1.5:
+quick-temp@0.1.6, quick-temp@^0.1.0, quick-temp@^0.1.2, quick-temp@^0.1.3, quick-temp@^0.1.5:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/quick-temp/-/quick-temp-0.1.6.tgz#a6242a15cba9f9cdbd341287b5c569e318eec307"
   dependencies:
@@ -3757,20 +3778,11 @@ readable-stream@~1.0.2:
     isarray "0.0.1"
     string_decoder "~0.10.x"
 
-recast@0.10.33:
+recast@0.10.33, recast@^0.10.10:
   version "0.10.33"
   resolved "https://registry.yarnpkg.com/recast/-/recast-0.10.33.tgz#942808f7aa016f1fa7142c461d7e5704aaa8d697"
   dependencies:
     ast-types "0.8.12"
-    esprima-fb "~15001.1001.0-dev-harmony-fb"
-    private "~0.1.5"
-    source-map "~0.5.0"
-
-recast@^0.10.10:
-  version "0.10.43"
-  resolved "https://registry.yarnpkg.com/recast/-/recast-0.10.43.tgz#b95d50f6d60761a5f6252e15d80678168491ce7f"
-  dependencies:
-    ast-types "0.8.15"
     esprima-fb "~15001.1001.0-dev-harmony-fb"
     private "~0.1.5"
     source-map "~0.5.0"
@@ -3950,6 +3962,10 @@ rollup@^0.41.4:
 rsvp@^3.0.14, rsvp@^3.0.16, rsvp@^3.0.17, rsvp@^3.0.18, rsvp@^3.0.21, rsvp@^3.0.6, rsvp@^3.1.0, rsvp@^3.2.1, rsvp@^3.3.3, rsvp@^3.4.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-3.5.0.tgz#a62c573a4ae4e1dfd0697ebc6242e79c681eaa34"
+
+rsvp@~3.0.6:
+  version "3.0.21"
+  resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-3.0.21.tgz#49c588fe18ef293bcd0ab9f4e6756e6ac433359f"
 
 rsvp@~3.2.1:
   version "3.2.1"


### PR DESCRIPTION
This PR adds two build-time config options:

  - `enableFlashFallback`: Exclude Flash callback from build if set to `false`. Default to `true`.

  - `flashFallbackDir`: The directory which the SWF file is placed inside the build. Default to `assets`.

Config access is done with `ember-get-config` addon which is addedto dependencies.

README file is updated to show the usage of the two new options.